### PR TITLE
feat(graph): graph coordinatizations, resolving sets and ball covers

### DIFF
--- a/Infrageometry/Kernel/Coordinatization.wl
+++ b/Infrageometry/Kernel/Coordinatization.wl
@@ -1,0 +1,113 @@
+Package["WolframInstitute`Infrageometry`"]
+
+(* Metric coordinatization and covering of graphs:
+   landmark (radar) coordinates and resolving sets, the resistance-matching
+   spectral embedding, and minimum ball covers (r-domination). *)
+
+PackageExport[RadarCoordinates]
+PackageExport[ResolvingSetQ]
+PackageExport[FindResolvingSet]
+PackageExport[MetricDimension]
+PackageExport[ResistanceCoordinates]
+PackageExport[FindBallCover]
+PackageExport[BallCoverQ]
+PackageExport[DominationNumber]
+PackageScope[resistanceEmbeddingMatrix]
+
+
+(* ===================== Radar coordinates & resolving sets ===================== *)
+
+(* distance vector of v to the landmark set b: (d(v, b_i))_i *)
+RadarCoordinates[g_Graph, b_List, v_] /; MemberQ[VertexList[g], v] :=
+    GraphDistance[g, v, #] & /@ b
+
+(* association vertex -> radar coordinates over all of g *)
+RadarCoordinates[g_Graph, b_List] :=
+    AssociationThread[VertexList[g], Outer[GraphDistance[g, #1, #2] &, VertexList[g], b, 1]]
+
+(* b resolves g iff the radar map v |-> (d(v, b_i))_i is injective over V(g) *)
+ResolvingSetQ[g_Graph, b_List] :=
+    DuplicateFreeQ[Outer[GraphDistance[g, #1, #2] &, VertexList[g], b, 1]]
+
+(* up to n resolving sets (metric bases) by ascending size; m restricts the
+   candidate sizes (All, an integer max, {min, max}, or {exact}). Subsets are
+   enumerated in size-then-Gosper order so the first found is smallest. *)
+FindResolvingSet[g_Graph, n_Integer : 1, m_ : All] :=
+    Module[{v = VertexList[g], dm = GraphDistanceMatrix[g], vc = VertexCount[g], found = {}, mask, last},
+        Map[v[[#]] &,
+            Catch[
+                Scan[
+                    k |-> (
+                        mask = 2^k - 1;
+                        last = BitShiftLeft[2^k - 1, vc - k];
+                        While[mask <= last,
+                            With[{s = Pick[Range[vc], IntegerDigits[mask, 2, vc], 1]},
+                                If[DuplicateFreeQ[dm[[All, s]]],
+                                    AppendTo[found, s];
+                                    If[Length[found] >= n, Throw[found]]
+                                ]
+                            ];
+                            (* Gosper's hack: next k-subset bitmask in lex order. *)
+                            mask = With[{c = BitAnd[mask, -mask]}, {r = mask + c},
+                                BitOr[r, Quotient[BitXor[r, mask], 4 c]]]
+                        ]
+                    ),
+                    Replace[m, {All :> Range[vc], _Integer :> Range[m], {min_, max_} :> Range[min, max], {num_} :> {num}}]
+                ];
+                Throw[found]
+            ]
+        ]
+    ]
+
+(* metric dimension: size of a smallest resolving set *)
+MetricDimension[g_Graph] := Length @ First @ FindResolvingSet[g, 1, All]
+
+
+(* ===================== Resistance coordinates ===================== *)
+
+Options[ResistanceCoordinates] = {"Rescaling" -> "ResistanceMatching", "Dimension" -> Automatic, "Origin" -> None};
+
+(* spectral embedding Phi with ||Phi(u) - Phi(v)||^2 == EffectiveResistance(u, v)
+   (Klein-Randic).  "Rescaling" -> "None" gives plain Laplacian eigenvectors,
+   "Diffusion" -> t the diffusion-map embedding; "Origin" -> v recentres on v. *)
+ResistanceCoordinates[g_Graph, opts : OptionsPattern[]] :=
+    With[{mat = resistanceEmbeddingMatrix[g, OptionValue["Rescaling"], OptionValue["Dimension"]], origin = OptionValue["Origin"]},
+        With[{originVec = If[origin === None, ConstantArray[0., Length @ First @ mat], mat[[ First @ FirstPosition[VertexList[g], origin] ]]]},
+            AssociationThread[VertexList[g], # - originVec & /@ mat]
+        ]
+    ]
+
+(* coordinates of a single vertex *)
+ResistanceCoordinates[g_Graph, v_, opts : OptionsPattern[]] /; MemberQ[VertexList[g], v] :=
+    ResistanceCoordinates[g, opts][v]
+
+resistanceEmbeddingMatrix[g_Graph, rescaling_, dimSpec_] :=
+    With[{es = Eigensystem[N @ Normal @ KirchhoffMatrix[g]]},
+        {ord = Ordering[es[[1]]]},
+        {vals = es[[1, ord]], vecs = es[[2, ord]]},
+        {keep = Select[Range @ Length @ vals, vals[[#]] > 10^-10 Max[Abs @ vals, 1] &]},
+        {idx = Take[keep, Replace[dimSpec, {Automatic | All :> Length[keep], UpTo[k_Integer] :> Min[k, Length[keep]], k_Integer :> Min[k, Length[keep]]}]]},
+        {weights = Replace[rescaling, {"ResistanceMatching" :> 1 / Sqrt[vals[[idx]]], "None" :> ConstantArray[1, Length[idx]], ("Diffusion" -> t_) :> Exp[-t vals[[idx]]]}]},
+        Transpose[weights vecs[[idx]]]
+    ]
+
+
+(* ===================== Ball covers & domination ===================== *)
+
+(* a minimum r-ball cover: a smallest centre set whose radius-r balls cover every
+   vertex (= a minimum r-dominating set), as a set-cover integer program. *)
+FindBallCover[g_Graph, r_ : 1] :=
+    With[{vs = VertexList[g], cover = Map[Boole[# <= r] &, GraphDistanceMatrix[g], {2}]},
+        With[{x = Array[\[FormalX], Length[vs]]},
+            vs[[ Flatten @ Position[x /. Last @ Minimize[{Total[x], And @@ Thread[cover . x >= 1], And @@ Thread[0 <= x <= 1]}, x, Integers], 1] ]]
+        ]
+    ]
+
+(* do the radius-r balls around the centres s cover every vertex of g? *)
+BallCoverQ[g_Graph, r_, s_List] :=
+    With[{dm = GraphDistanceMatrix[g], pos = Flatten[FirstPosition[VertexList[g], #] & /@ s]},
+        AllTrue[dm, row |-> AnyTrue[pos, j |-> row[[j]] <= r]]
+    ]
+
+(* r-domination number: size of a minimum r-ball cover *)
+DominationNumber[g_Graph, r_ : 1] := Length @ FindBallCover[g, r]

--- a/Infrageometry/Kernel/Usage.wl
+++ b/Infrageometry/Kernel/Usage.wl
@@ -208,3 +208,12 @@ ConnectionZetaFunction::usage = "ConnectionZetaFunction[g, s] gives the spectral
 LefschetzZetaFunction::usage = "LefschetzZetaFunction[g, perm, z] gives the Lefschetz zeta function exp(sum L(T^n)/n z^n) for automorphism perm.";
 AnalyticTorsion::usage = "AnalyticTorsion[g] gives the analytic torsion exp(1/2 sum (-1)^{k+1} k log det'(H_k)) of complex g.";
 IndexExpectationCurvature::usage = "IndexExpectationCurvature[g] gives the index-expectation curvature K(x)=E[1-chi(S(x) cap {f<f(x)})], satisfying Gauss-Bonnet: sum K = chi.";
+
+RadarCoordinates::usage = "RadarCoordinates[g, basis, v] gives the distance vector (d(v, b))_{b in basis} of vertex v; RadarCoordinates[g, basis] gives the association of all vertices' radar coordinates.";
+ResolvingSetQ::usage = "ResolvingSetQ[g, basis] tests whether basis is a resolving set: the radar map v |-> (d(v, b))_{b in basis} is injective over the vertices.";
+FindResolvingSet::usage = "FindResolvingSet[g, n, m] returns up to n resolving sets (metric bases) of g by ascending size; m restricts the sizes (All, an integer max, {min, max}, or {exact}).";
+MetricDimension::usage = "MetricDimension[g] gives the metric dimension of g: the size of a smallest resolving set.";
+ResistanceCoordinates::usage = "ResistanceCoordinates[g] gives the association vertex -> spectral embedding Phi with ||Phi(u)-Phi(v)||^2 == EffectiveResistance[g,u,v]; options \"Rescaling\" (\"ResistanceMatching\" | \"None\" | \"Diffusion\"->t), \"Dimension\", \"Origin\". ResistanceCoordinates[g, v] gives the coordinates of v.";
+FindBallCover::usage = "FindBallCover[g, r] returns a minimum r-ball cover of g: a smallest set of centres whose radius-r balls cover every vertex (a minimum r-dominating set).";
+BallCoverQ::usage = "BallCoverQ[g, r, S] tests whether the radius-r balls around the centres S cover every vertex of g.";
+DominationNumber::usage = "DominationNumber[g, r] gives the r-domination number of g: the size of a minimum r-ball cover.";

--- a/Infrageometry/Tests/InfrageometryTests.wlt
+++ b/Infrageometry/Tests/InfrageometryTests.wlt
@@ -1657,4 +1657,81 @@ VerificationTest[
 ]
 
 
+(* ===== Coordinatization: resolving sets, radar / resistance coords, ball covers ===== *)
+
+VerificationTest[
+    ResolvingSetQ[PathGraph[Range[5]], {1}],
+    True,
+    TestID -> "ResolvingSetQ-path-endpoint-resolves"
+]
+
+VerificationTest[
+    ResolvingSetQ[CycleGraph[6], {1}],
+    False,
+    TestID -> "ResolvingSetQ-cycle-single-fails"
+]
+
+VerificationTest[
+    ResolvingSetQ[CycleGraph[6], {1, 2}],
+    True,
+    TestID -> "ResolvingSetQ-cycle-two-resolves"
+]
+
+VerificationTest[
+    MetricDimension[PathGraph[Range[5]]],
+    1,
+    TestID -> "MetricDimension-path"
+]
+
+VerificationTest[
+    MetricDimension[CycleGraph[6]],
+    2,
+    TestID -> "MetricDimension-cycle"
+]
+
+VerificationTest[
+    MetricDimension[PetersenGraph[]],
+    3,
+    TestID -> "MetricDimension-Petersen"
+]
+
+VerificationTest[
+    RadarCoordinates[PathGraph[Range[5]], {1, 5}, 3],
+    {2, 2},
+    TestID -> "RadarCoordinates-path-vertex"
+]
+
+VerificationTest[
+    With[{c = ResistanceCoordinates[PathGraph[Range[4]]]},
+        Chop[Total[(c[1] - c[4])^2] - EffectiveResistance[PathGraph[Range[4]], 1, 4]]
+    ],
+    0,
+    TestID -> "ResistanceCoordinates-matching-identity"
+]
+
+VerificationTest[
+    DominationNumber[CycleGraph[7], 2],
+    2,
+    TestID -> "DominationNumber-C7-r2"
+]
+
+VerificationTest[
+    DominationNumber[PetersenGraph[], 1],
+    3,
+    TestID -> "DominationNumber-Petersen-r1"
+]
+
+VerificationTest[
+    BallCoverQ[CycleGraph[7], 2, FindBallCover[CycleGraph[7], 2]],
+    True,
+    TestID -> "FindBallCover-covers-C7"
+]
+
+VerificationTest[
+    BallCoverQ[CycleGraph[7], 1, {1}],
+    False,
+    TestID -> "BallCoverQ-single-ball-too-small"
+]
+
+
 EndTestSection[]


### PR DESCRIPTION
## Summary

Adds the **metric-substrate** utilities for landmark coordinatization and covering of graphs. Most are **relocated from `SyntheticInfrageometry`** with plain (non-`Infra`) names, per the substrate ↔ synthetic boundary we're adopting: general metric/graph algorithms live in Infrageometry; `InfraObject`-aware behaviour stays in Synthetic as overloads.

New module `Kernel/Coordinatization.wl`:

| Symbol | Meaning | Origin |
|---|---|---|
| `RadarCoordinates[g, basis, v]` / `[g, basis]` | distance vector to a landmark set | relocated |
| `ResolvingSetQ[g, b]` | radar map is injective | relocated (`InfraRadarBasisQ`) |
| `FindResolvingSet[g, n, m]` | resolving sets / metric bases, ascending size | relocated (`FindInfraRadarBasis`) |
| `MetricDimension[g]` | size of a smallest resolving set | new companion |
| `ResistanceCoordinates[g]` / `[g, v]` | Klein–Randić resistance-matching spectral embedding | relocated |
| `FindBallCover[g, r]` | minimum r-ball cover = minimum r-dominating set | **new** |
| `BallCoverQ[g, r, S]` | do the radius-r balls around S cover V? | **new** |
| `DominationNumber[g, r]` | size of a minimum r-ball cover | **new** |

All implementations are **crisp** (no `InfraObject` coupling) and use only `GraphDistance`/`GraphDistanceMatrix`/`KirchhoffMatrix` + the existing `EffectiveResistance`.

## Verification

Full suite: **228/228 pass** (12 new coordinatization tests). Highlights asserted as math, not internals:
- `MetricDimension`: path → 1, C₆ → 2, Petersen → 3.
- Resistance-matching identity `‖Φ(u) − Φ(v)‖² == EffectiveResistance(u, v)`.
- `DominationNumber`: C₇/r=2 → 2, Petersen/r=1 → 3; `BallCoverQ` confirms coverage.

## Follow-up (separate PR, on SyntheticInfrageometry)

Bump the Infrageometry dependency, delete the relocated definitions, re-add the `InfraPoint`-aware overloads on these same symbols, and keep `FindInfraRadarBasis`/`InfraRadarBasisQ` as deprecation aliases. `OrthogonalCoordinates` / `FindInfraOrthogonalFrame` (InfraPoint axes) stay in Synthetic.

Squash-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)