### PR TITLE
feat(tda): graph-metric ball-intersection and subcover targets

### DIFF
--- a/Infrageometry/Kernel/Coordinatization.wl
+++ b/Infrageometry/Kernel/Coordinatization.wl
@@ -94,20 +94,24 @@ resistanceEmbeddingMatrix[g_Graph, rescaling_, dimSpec_] :=
 
 (* ===================== Ball covers & domination ===================== *)
 
-(* a minimum r-ball cover: a smallest centre set whose radius-r balls cover every
-   vertex (= a minimum r-dominating set), as a set-cover integer program. *)
-FindBallCover[g_Graph, r_ : 1] :=
-    With[{vs = VertexList[g], cover = Map[Boole[# <= r] &, GraphDistanceMatrix[g], {2}]},
-        With[{x = Array[\[FormalX], Length[vs]]},
-            vs[[ Flatten @ Position[x /. Last @ Minimize[{Total[x], And @@ Thread[cover . x >= 1], And @@ Thread[0 <= x <= 1]}, x, Integers], 1] ]]
-        ]
+(* a minimum r-ball cover: a smallest centre set (chosen from all of V) whose radius-r
+   balls cover the targets (every vertex by default, or a given subset) as a set-cover
+   integer program. targets restricts the covered rows; centres range over all of V. *)
+FindBallCover[g_Graph, r_ : 1, targets : (_List | All) : All] :=
+    With[
+        {vs = VertexList[g]},
+        {rows = If[targets === All, Range[Length[vs]], Flatten[FirstPosition[vs, #] & /@ targets]]},
+        {cover = Map[Boole[# <= r] &, GraphDistanceMatrix[g][[rows]], {2}], x = Array[\[FormalX], Length[vs]]},
+        vs[[ Flatten @ Position[x /. Last @ Minimize[{Total[x], And @@ Thread[cover . x >= 1], And @@ Thread[0 <= x <= 1]}, x, Integers], 1] ]]
     ]
 
-(* do the radius-r balls around the centres s cover every vertex of g? *)
-BallCoverQ[g_Graph, r_, s_List] :=
-    With[{dm = GraphDistanceMatrix[g], pos = Flatten[FirstPosition[VertexList[g], #] & /@ s]},
-        AllTrue[dm, row |-> AnyTrue[pos, j |-> row[[j]] <= r]]
+(* do the radius-r balls around the centres s cover the targets (all of V by default)? *)
+BallCoverQ[g_Graph, r_, s_List, targets : (_List | All) : All] :=
+    With[
+        {vs = VertexList[g], dm = GraphDistanceMatrix[g]},
+        {pos = Flatten[FirstPosition[vs, #] & /@ s], rows = If[targets === All, dm, dm[[Flatten[FirstPosition[vs, #] & /@ targets]]]]},
+        AllTrue[rows, row |-> AnyTrue[pos, j |-> row[[j]] <= r]]
     ]
 
-(* r-domination number: size of a minimum r-ball cover *)
-DominationNumber[g_Graph, r_ : 1] := Length @ FindBallCover[g, r]
+(* r-domination number: size of a minimum r-ball cover (of the targets) *)
+DominationNumber[g_Graph, r_ : 1, targets : (_List | All) : All] := Length @ FindBallCover[g, r, targets]

--- a/Infrageometry/Kernel/TDA.wl
+++ b/Infrageometry/Kernel/TDA.wl
@@ -137,6 +137,11 @@ CechComplex[data_List, r_ ? NumericQ, opts : OptionsPattern[BallIntersectionComp
    centres (Euclidean) or, over a finite metric, the smallest r for which some
    sample point lies within r of every centre (intrinsic intersection oracle). *)
 commonRadiusFn[data_, EuclideanDistance] := s |-> MiniballRadius[data[[s]]]
+(* graph metric: data are centre vertices (any subset of V); a common point may be
+   ANY vertex, so candidates range over all of V while columns track the centres. *)
+commonRadiusFn[data_, g_ ? GraphQ] :=
+    With[{rows = GraphDistanceMatrix[g][[ Flatten[FirstPosition[VertexList[g], #] & /@ data] ]]},
+        s |-> Min[Max /@ Transpose[rows[[s]]]]]
 commonRadiusFn[data_, metric_] := With[{mat = metricMatrix[data, metric]}, s |-> Min[Max /@ mat[[All, s]]]]
 
 metricMatrix[data_, m_ ? MatrixQ] := m

--- a/Infrageometry/Tests/InfrageometryTests.wlt
+++ b/Infrageometry/Tests/InfrageometryTests.wlt
@@ -1857,5 +1857,22 @@ VerificationTest[
     TestID -> "BallCoverQ-single-ball-too-small"
 ]
 
+(* a cover of a vertex subset covers its targets and can be smaller than a full cover *)
+VerificationTest[
+    With[{g = PathGraph[Range[7]]},
+        {BallCoverQ[g, 1, FindBallCover[g, 1, {1, 7}], {1, 7}], DominationNumber[g, 1, {1, 7}] < DominationNumber[g, 1]}
+    ],
+    {True, True},
+    TestID -> "FindBallCover-subset-covers-targets"
+]
+
+(* nerve of chosen graph-metric centres: B(2),B(4),B(6) at r=1 on the path meet
+   consecutively (shared vertices 3, 5) but the ends miss, giving the path complex *)
+VerificationTest[
+    Sort @ BallIntersectionComplex[{2, 4, 6}, 1, Infinity, "Metric" -> PathGraph[Range[7]]],
+    {{1}, {2}, {3}, {1, 2}, {2, 3}},
+    TestID -> "BallIntersectionComplex-graph-chosen-centres"
+]
+
 
 EndTestSection[]


### PR DESCRIPTION
## Summary

Two additive, composable pieces that let the ball-intersection / Čech machinery run over a **graph** metric and on a **subcover**.

- **Graph-metric oracle** — `commonRadiusFn[data, g_?GraphQ]`: `CechComplex` and `BallIntersectionComplex` now accept `"Metric" -> g`, treating `data` as centre vertices (any subset of V); a common point may be any vertex of `g`.
- **Subcover targets** — optional `targets` argument on `FindBallCover` / `BallCoverQ` / `DominationNumber`: cover a vertex *subset* while centres still range over all of V.

## Tests

Two new tests (suite **241/241**):
- subset cover is valid and `DominationNumber[g, 1, {1,7}] < DominationNumber[g, 1]`;
- `BallIntersectionComplex[{2,4,6}, 1, ∞, "Metric" -> PathGraph[7]]` gives the expected path nerve `{{1},{2},{3},{1,2},{2,3}}`.

Non-breaking: new `GraphQ` overload + optional trailing argument; existing signatures unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)